### PR TITLE
Adds the ability to ignore repos by full name

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Sometimes you don't want to retrieve that gigantic project that
 someone committed `.mov` files to.
 
     [ignores]
-    repo: icloud, facebook
+    repo: icloud, facebook, pearkes/bootstrap
     owner: adobe
 
 ## Contributing

--- a/steps/step_check_repo.go
+++ b/steps/step_check_repo.go
@@ -21,7 +21,7 @@ func (*StepCheckRepo) Run(state multistep.StateBag) multistep.StepAction {
 
 	// Check if the repo is ignored by it's name
 	for _, ignoredName := range ignoredRepos {
-		if ignoredName == repo.Name() {
+		if ignoredName == repo.Name() || ignoredName == repo.FullName {
 			state.Put("repo_state", "ignore")
 			state.Put("repo_result", "ignore")
 			return multistep.ActionContinue

--- a/steps/step_check_repo_test.go
+++ b/steps/step_check_repo_test.go
@@ -93,3 +93,61 @@ func TestStepCheckRepo_Ignore_Owner(t *testing.T) {
 
 	os.RemoveAll("tmp")
 }
+
+func TestStepCheckRepo_Ignore_Repo_Name(t *testing.T) {
+	env := new(multistep.BasicStateBag)
+
+	os.MkdirAll("tmp", 0777)
+	env.Put("path", "tmp")
+	env.Put("ignored_owners", []string{})
+	env.Put("ignored_repos", []string{"bootstrap"})
+
+	repo := Repo{FullName: "pearkes/bootstrap"}
+
+	env.Put("repo", repo)
+
+	step := &StepCheckRepo{}
+
+	results := step.Run(env)
+
+	state := env.Get("repo_state").(string)
+
+	if state != "ignore" {
+		t.Fatal("repo state does not match ignore")
+	}
+
+	if results != multistep.ActionContinue {
+		t.Fatal("step did not return ActionContinue")
+	}
+
+	os.RemoveAll("tmp")
+}
+
+func TestStepCheckRepo_Ignore_Repo_FullName(t *testing.T) {
+	env := new(multistep.BasicStateBag)
+
+	os.MkdirAll("tmp", 0777)
+	env.Put("path", "tmp")
+	env.Put("ignored_owners", []string{})
+	env.Put("ignored_repos", []string{"pearkes/bootstrap"})
+
+	repo := Repo{FullName: "pearkes/bootstrap"}
+
+	env.Put("repo", repo)
+
+	step := &StepCheckRepo{}
+
+	results := step.Run(env)
+
+	state := env.Get("repo_state").(string)
+
+	if state != "ignore" {
+		t.Fatal("repo state does not match ignore")
+	}
+
+	if results != multistep.ActionContinue {
+		t.Fatal("step did not return ActionContinue")
+	}
+
+	os.RemoveAll("tmp")
+}

--- a/steps/step_inject_configuration_test.go
+++ b/steps/step_inject_configuration_test.go
@@ -23,6 +23,7 @@ func TestStepInjectConfiguration(t *testing.T) {
 	conf.AddOption("github", "username", "foo")
 	conf.AddOption("github", "token", "bar")
 	conf.AddOption("ignores", "repo", "facebook")
+	conf.AddOption("ignores", "repo", "pearkes/bootstrap")
 	conf.AddOption("ignores", "owner", "pearkes")
 
 	conf.WriteFile("tmp/.gethubconfig", 0644, "")


### PR DESCRIPTION
Repositories can potentially have the same name under different owners.
In some cases, one may wish to ignore one of these repos while backing
up the other. Previously this was not possible since the ignore would
apply to both.
