### PR TITLE
Update gopass calls to work with the latest version

### DIFF
--- a/steps/step_authorize_github.go
+++ b/steps/step_authorize_github.go
@@ -69,6 +69,7 @@ authorization token from GitHub's API, which will be stored in
 	t, err := gopass.GetPasswd()
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	token := string(t)
@@ -108,6 +109,7 @@ authorization token from GitHub's API, which will be stored in
 	p, err := gopass.GetPasswd()
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	fmt.Printf("\n")

--- a/steps/step_authorize_github.go
+++ b/steps/step_authorize_github.go
@@ -66,7 +66,11 @@ authorization token from GitHub's API, which will be stored in
 
 	fmt.Printf("If you use Two-Factor Authentication, enter a generated personal access token now. (Otherwise, press enter to skip and use a password): ")
 
-	t := gopass.GetPasswd()
+	t, err := gopass.GetPasswd()
+	if err != nil {
+		fmt.Println(err)
+	}
+
 	token := string(t)
 
 	if token != "" {
@@ -101,7 +105,11 @@ authorization token from GitHub's API, which will be stored in
 
 	fmt.Printf("Please enter your GitHub password: ")
 
-	p := gopass.GetPasswd()
+	p, err := gopass.GetPasswd()
+	if err != nil {
+		fmt.Println(err)
+	}
+
 	fmt.Printf("\n")
 
 	password := string(p)


### PR DESCRIPTION
Hey!

I recently tried to install get hub using `go install github.com/pearkes/gethub` but it didn't work because the gopass library has been updated. This pull request updates the calls to match the latest version.